### PR TITLE
Rename module

### DIFF
--- a/caddy/caddymain/run.go
+++ b/caddy/caddymain/run.go
@@ -122,6 +122,7 @@ func Run() {
 			log.SetOutput(f)
 		}
 	}
+	log.Printf("MJH: my version\n")
 
 	// load all additional envs as soon as possible
 	if err := LoadEnvFromFile(envFile); err != nil {


### PR DESCRIPTION
This change renames the go module to webscale-networks/caddy so
it can be imported into the control repo.